### PR TITLE
Update library to use packaged @most/create

### DIFF
--- a/most-w3msg.js
+++ b/most-w3msg.js
@@ -5,7 +5,7 @@
 /* globals Promise */
 
 var most = require('most');
-var create = most.create;
+var create = require('@most/create');
 var fromPromise = most.fromPromise;
 
 var defaultMessageEvent = 'message';

--- a/package.json
+++ b/package.json
@@ -16,10 +16,13 @@
   "author": "brian@hovercraftstudios.com",
   "license": "MIT",
   "devDependencies": {
+    "@most/create": "^1.1.3",
+    "buster": "~0.8",
     "jshint": "~2.9",
-    "buster": "~0.8"
+    "most": "^1.0.3"
   },
   "peerDependencies": {
-    "most": "^0.19.7"
+    "most": "^1.0.0",
+    "@most/create": "^1.1.0"
   }
 }


### PR DESCRIPTION
After the removal of `create` from vanilla most, this package requires the `@most/create` package and sets it as a peer dependecy of this lib.

- - -

Somewhat related: even after poking around the most repo, I haven't been able to find out _why_ `create` was removed. Was it to shrink the surface area of ways a stream could be instantiated? Is this PR performing the right thing conceptually? Should it shim, for example, something like `fromEvent` in order to listen to the socket?